### PR TITLE
Add distillation and automated labelling section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Collect some resource about Segment Anything (SAM), including latest papers and 
 
 - [[**SEEM**](https://github.com/UX-Decoder/Segment-Everything-Everywhere-All-At-Once)]: SEEM allows users to easily segment an image using prompts of different types including visual prompts (points, marks, boxes, scribbles and image segments) and language prompts (text and audio), etc 
 
-### Distillation
+### Distillation and Automated Labeling
 
 - [Autodistill](https://github.com/autodistill/autodistill): Images to inference with no labeling (use foundation models to train supervised models). `autodistill` features a `autodistill-grounded-sam` module that enables automated image annotation using Grounding DINO and SAM.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Collect some resource about Segment Anything (SAM), including latest papers and 
 
 - [[**SEEM**](https://github.com/UX-Decoder/Segment-Everything-Everywhere-All-At-Once)]: SEEM allows users to easily segment an image using prompts of different types including visual prompts (points, marks, boxes, scribbles and image segments) and language prompts (text and audio), etc 
 
+### Distillation
+
+- [Autodistill](https://github.com/autodistill/autodistill): Images to inference with no labeling (use foundation models to train supervised models). `autodistill` features a `autodistill-grounded-sam` module that enables automated image annotation using Grounding DINO and SAM.
 
 ### 3D 
 - [[**3D-Box via Segment Anything**](https://github.com/dvlab-research/3D-Box-Segment-Anything)]:  In this project, we extend the scope to 3D world by combining Segment Anything and VoxelNeXt. When we provide a prompt (e.g., a point / box), the result is not only 2D segmentation mask, but also 3D boxes.


### PR DESCRIPTION
This PR adds a new distillation and automated labelling section to the README, under which [Autodistill](https://github.com/autodistill/autodistill), an open source ecosystem for using foundation vision models to train smaller models is added.